### PR TITLE
DOC-1169 running tests against multiple envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,26 @@ With the exception of Visual Studio Code, these prerequisites should be installe
 5. Open Terminal within Visual Studio Code and install the dependencies by running `npm install` from the terminal
 6. Open Terminal within Visual Studio Code and install the dependencies by running `sudo apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb` from the terminal
 
-## Local Usage
+## Running Tests
 
-The file 'package.json' contains the commands to run scripts, and these are all declared in 'scripts' object.
+The file 'package.json' contains the commands to run scripts, and these are all declared in 'scripts' object. The tests are executed in a Chrome browser with the tag filter `not @ignore`.
 
-1. `npm run cypress:test` Opens the Cypress Test Runner
-2. `npm run cypress:all` Runs the feature file(s) with specified tags in a Chrome browser. Specify tags within "TAGS=" and "--tag" prior to running
+### Running Cypress Tests in Interactive Mode
+
+In this mode, Cypress opens the interactive Test Runner, allowing you to manually run and observe tests in the browser. 
+
+1. `npm run cypress:local` - Opens the Test Runner for the Local environment.
+2. `npm run cypress:dev` - Opens the Test Runner for the Dev Environment.
+3. `npm run cypress:test` - Opens the Test Runner for the Test Environment.
+
+### Running Cypress Tests in Headless Mode (cypress run)
+
+In this mode, Cypress runs tests all tests at once and generates a HTML report after.
+
+1. `npm run cypress:local` Runs all tests for the Local environment.
+2. `npm run cypress:dev` Runs all tests for the Dev environment.
+3. `npm run cypress:test` Runs all tests for the Test environment.
 <br>
 <br>
 <br>
-*Last updated: 15th March 2024*
+*Last updated: 9th September 2024*

--- a/cypress/integration/steps/common.js
+++ b/cypress/integration/steps/common.js
@@ -1,17 +1,19 @@
 /* global Given, When, Then */
 
-import environments from '../../support/environments.json';
 import paymentManagementPage from '../pages/paymentManagementPage';
+const { getEnvironmentConfig } = require('../../support/configLoader');
+
+const envConfig = getEnvironmentConfig();
 
 Given(/^I visit the "(.*)" homepage$/, (text) => {
   var url;
 
   switch (text) {
   case 'Payment management':
-    url = environments.paymentManagement.testUrl;
+    url = envConfig.paymentManagementUrl;
     break;
   case 'Request Editor':
-    url = environments.requestEditor.testUrl;
+    url = envConfig.requestEditorUrl;
     break;
   }
 
@@ -24,10 +26,10 @@ Given(/^I am on the "(.*)" homepage$/, (text) => {
 
   switch (text) {
   case 'Payment management':
-    url = environments.paymentManagement.testUrl;
+    url = envConfig.paymentManagementUrl;
     break;
   case 'Request Editor':
-    url = environments.requestEditor.testUrl;
+    url = envConfig.requestEditorUrl;
     break;
   }
 

--- a/cypress/support/configLoader.js
+++ b/cypress/support/configLoader.js
@@ -1,0 +1,12 @@
+const environments = require('./environments.json');
+
+function getEnvironmentConfig () {
+  const env = Cypress.env('env') || 'local';  // default to local if not specified
+
+  return {
+    paymentManagementUrl: environments.paymentManagement[`${env}Url`],
+    requestEditorUrl: environments.requestEditor[`${env}Url`]
+  };
+}
+
+module.exports = { getEnvironmentConfig };

--- a/cypress/support/environments.json
+++ b/cypress/support/environments.json
@@ -1,10 +1,12 @@
 {
   "paymentManagement": {
     "testUrl": "https://ffc-pay-web-test.azure.defra.cloud/",
-    "devUrl": "https://ffc-pay-web-dev.azure.defra.cloud/"
+    "devUrl": "https://ffc-pay-web-dev.azure.defra.cloud/",
+    "localUrl": "http://localhost:3007/"
   },
   "requestEditor": {
     "testUrl": "https://ffc-pay-request-editor-test.azure.defra.cloud/",
-    "devUrl": "https://ffc-pay-request-editor-dev.azure.defra.cloud/"
+    "devUrl": "https://ffc-pay-request-editor-dev.azure.defra.cloud/",
+    "localUrl": "http://localhost:3001/"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "cypress:test": "cypress open --e2e --browser=chrome --env 'TAGS=not @ignore'",
-    "cypress:all": "npm run config:reports; npm run delete:reports; ./node_modules/.bin/cypress-tags run -e TAGS='not @ignore' --browser chrome --headed; npm run report",
+    "cypress:local": "cypress open --e2e --browser=chrome --env env=local,TAGS='not @ignore'",
+    "cypress:dev": "cypress open --e2e --browser chrome --env env=dev,TAGS='not @ignore'",
+    "cypress:test": "cypress open --e2e --browser=chrome --env env=test,TAGS='not @ignore'",
+    "cypress:all:local": "npm run config:reports; npm run delete:reports; ./node_modules/.bin/cypress-tags run --env env=local,TAGS='not @ignore' --browser chrome --headed; npm run report",
+    "cypress:all:dev": "npm run config:reports; npm run delete:reports; ./node_modules/.bin/cypress-tags run --env env=dev,TAGS='not @ignore' --browser chrome --headed; npm run report",
+    "cypress:all:test": "npm run config:reports; npm run delete:reports; ./node_modules/.bin/cypress-tags run --env env=test,TAGS='not @ignore' --browser chrome --headed; npm run report",
     "report": "node .tools/exportHTMLReport.mjs",
     "delete:reports": "rm -rf report/JSON/* || true; rm -rf report/HTML/* || true; rm -rf cypress/videos/features/* || true",
-    "config:reports": "mkdir -p report/{HTML,JSON} cypress/screenshots; cp '.tools/createTestFromScenario.js' 'node_modules/cypress-cucumber-preprocessor/lib/createTestFromScenario.js'",
-    "github-chrome": "./node_modules/.bin/cypress-tags run -e TAGS='@runthis and not @ignore' --browser chrome"
+    "config:reports": "mkdir -p report/{HTML,JSON} cypress/screenshots; cp '.tools/createTestFromScenario.js' 'node_modules/cypress-cucumber-preprocessor/lib/createTestFromScenario.js'"
   },
   "dependencies": {
     "@azure/service-bus": "^7.9.3",


### PR DESCRIPTION
This PR allows for Cypress tests to be executed against dev, test or local env at a click of a button.

Some tests will fail on certain envs - a follow up ticket will be created for these failures to be addressed and/or tagged appropriately to prevent failures.