### PR TITLE
Event monitoring extension

### DIFF
--- a/cypress/integration/features/42_PaymentEventMonitoring.feature
+++ b/cypress/integration/features/42_PaymentEventMonitoring.feature
@@ -1,13 +1,20 @@
 @local
 Feature: 42 Payment Event Monitoring
 
+#####################################READ BEFORE RUNNING##########################################
+
+#As the later scenarios in this feature file are intended to test the ordering and processing of payment request following PPAs,
+#Before running this script, 32_SFI23Payments.feature should be ran.
+#This will create the data needed for this feature.
+
+##################################################################################################
+
 # This feature file is designed to test functionality of Payment Event Monitoring section in Payment Management UI
 
   Scenario: 01 Confirm initial elements on View events page
 
 # This scenario confirms that the correct elements are displayed on initial View events page load  
 
-    Given I restart the local environment
     Given I visit the "Payment management" homepage
     When I click on the "View events" link
 
@@ -36,29 +43,7 @@ Feature: 42 Payment Event Monitoring
     Then on the View processed payment requests page I confirm that "select scheme button" is displayed
     Then I take a screenshot for Feature 42 and Scenario 2
 
-  Scenario: 03 Load payment test data for later scenarios
-
-# This scenario loads payment data for use in following scenarios  
-
-    When I send the updated "sfi23-paymentFileMessage" message to the service bus topic "ffc-pay-request-aw"
-
-#The following steps confirm that the data has been passed along to the correct services and that the data
-#has been processed correctly
-
-    Then I confirm that payment test data has been inserted into the ffc-pay-processing database
-    Then I confirm that payment test data has been inserted into the ffc-pay-submission database
-
-#The following step downloads file from Azure Blob Storage and confirms that the values given in the data inserted into the 
-#Pay Submission Service have been correctly added to the generated statement
-
-    Then I pull sfi23 payments file from Azure Blob Storage and confirm that correct values have been generated
-
-#Send return file
-
-    When I send the updated "sfi23-returnFileMessage" message to the service bus topic "ffc-pay-return-aw"
-    Then I confirm that return test data has been inserted into the ffc-pay-processing database
-
-  Scenario: 04 Search by FRN on View events page
+  Scenario: 03 Search by FRN on View events page
 
 #This scenario confirms that correct page elements are displayed when searching events by FRN  
 
@@ -77,9 +62,9 @@ Feature: 42 Payment Event Monitoring
     Then on the View events page I confirm that "status column" is displayed
     Then on the View events page I confirm that "last updated column" is displayed
     Then on the View events page I confirm that "actions column" is displayed
-    Then I take a screenshot for Feature 42 and Scenario 4
+    Then I take a screenshot for Feature 42 and Scenario 3
 
-  Scenario: 05 Search by Batch name on View events page
+  Scenario: 04 Search by Batch name on View events page
 
 #This scenario confirms that correct page elements are displayed when searching events by Batch name  
 
@@ -99,10 +84,10 @@ Feature: 42 Payment Event Monitoring
     Then on the View events page I confirm that "batch value column" is displayed
     Then on the View events page I confirm that "batch status column" is displayed
     Then on the View events page I confirm that "batch actions column" is displayed
-    Then I take a screenshot for Feature 42 and Scenario 5
+    Then I take a screenshot for Feature 42 and Scenario 4
 
 
-  Scenario: 06 Click View in Actions column and confirm page
+  Scenario: 05 Click View in Actions column and confirm page
 
 #This scenario confirms that correct page elements are displayed when clicking View link in the Actions column
 
@@ -124,9 +109,9 @@ Feature: 42 Payment Event Monitoring
     Then I should see "Settled"
     Then I should see "Acknowledged"
 
-    Then I take a screenshot for Feature 42 and Scenario 6
+    Then I take a screenshot for Feature 42 and Scenario 5
 
-  Scenario: 07 Confirm page elements when no results found
+  Scenario: 06 Confirm page elements when no results found
 
 #This scenario confirms that correct page elements are displayed when no results are found in View Events
 
@@ -137,9 +122,9 @@ Feature: 42 Payment Event Monitoring
     Then on the View events page I click the "frn search button"
 
     Then I should see "No payments found for FRN 1111111111."
-    Then I take a screenshot for Feature 42 and Scenario 7
+    Then I take a screenshot for Feature 42 and Scenario 6
 
-  Scenario: 08 View processed payment requests by scheme
+  Scenario: 07 View processed payment requests by scheme
 
 #This scenario confirms that correct page elements are displayed when viewing processed payment requests by scheme
 
@@ -153,9 +138,9 @@ Feature: 42 Payment Event Monitoring
     Then on the View processed payment requests page I confirm that "scheme column" is displayed
     Then on the View processed payment requests page I confirm that "number of payments column" is displayed
     Then on the View processed payment requests page I confirm that "value column" is displayed
-    Then I take a screenshot for Feature 42 and Scenario 8
+    Then I take a screenshot for Feature 42 and Scenario 7
 
-  Scenario: 09 Confirm correct message when no results found
+  Scenario: 08 Confirm correct message when no results found
 
 #This scenario confirms that correct page elements are displayed when no results are found in View processed payment requests
 
@@ -165,4 +150,45 @@ Feature: 42 Payment Event Monitoring
     Then on the View processed payment requests page I select "SFI" in scheme dropdown
     Then on the View processed payment requests page I click the Continue button
     Then I should see "No processed payment requests found."
+    Then I take a screenshot for Feature 42 and Scenario 8
+
+  Scenario: 09 Confirm that payment request data is processed and ordered correctly
+
+    Given I visit the "Payment management" homepage
+    When I click on the "View events" link
+
+    Then on the View events page I enter "1258445148" into the "frn" field
+    Then on the View events page I click the "frn search button"
+
+  #Confirm that rows are ordered correctly by payment request number  
+
+    Then on the View events page I confirm that rows are ordered correctly by payment request
+
+  #Confirm that first payment request entry has original payment request value of £100,000.00
+
+    Then on the View events page I confirm that "value" of entry number "1" in table is "100,000.00"
+    Then on the View events page I confirm that "value" of entry number "2" in table is "10,000.00"
+
+  #Confirm that no fields are blank
+
+    Then on the View events page I confirm that "scheme" of entry number "1" in table is "SFI23"
+    Then on the View events page I confirm that "agreement" of entry number "1" in table is "40770826"
+    Then on the View events page I confirm that "payment request" of entry number "1" in table is "1"
+    Then on the View events page I confirm that "status" of entry number "1" in table is "Settled by payment ledger"
+    Then on the View events page I confirm that "last updated" of entry number "1" in table is "Today"
+
+    Then on the View events page I confirm that "scheme" of entry number "2" in table is "SFI23"
+    Then on the View events page I confirm that "agreement" of entry number "2" in table is "40770826"
+    Then on the View events page I confirm that "payment request" of entry number "2" in table is "2"
+    Then on the View events page I confirm that "status" of entry number "2" in table is "Submitted to payment ledger"
+    Then on the View events page I confirm that "last updated" of entry number "2" in table is "Today"
+
     Then I take a screenshot for Feature 42 and Scenario 9
+
+    
+
+
+
+
+
+  

--- a/cypress/integration/pages/paymentEventMonitoringPage.js
+++ b/cypress/integration/pages/paymentEventMonitoringPage.js
@@ -139,6 +139,14 @@ class paymentEventMonitoringPage {
   processedRequestsValueColumn () {
     return cy.get('.govuk-table__head > .govuk-table__row > :nth-child(3)');
   }
+
+  firstPaymentRequestNumber () {
+    return cy.get('.govuk-table__body > :nth-child(1) > :nth-child(3)');
+  }
+
+  secondPaymentRequestNumber () {
+    return cy.get('.govuk-table__body > :nth-child(2) > :nth-child(3)');
+  }
 }
 
 export default new paymentEventMonitoringPage();

--- a/cypress/integration/steps/common.js
+++ b/cypress/integration/steps/common.js
@@ -21,8 +21,8 @@ Given(/^I visit the "(.*)" homepage$/, (text) => {
     url = envConfig.paymentCalculatorUrl;
     break;
   }
-  cy.log("URL to open " + url);
-  console.log("URL to open " + url);
+  cy.log('URL to open ' + url);
+  console.log('URL to open ' + url);
 
   cy.visit(url);
   cy.wait(2000);
@@ -99,7 +99,7 @@ Then(/^I confirm there are no accessibility issues on the page$/, () => {
       cy.log(`Description: ${description}`);
       cy.log(`Help: ${help}`);
       cy.log(`More info: ${helpUrl}`);
-      cy.log(`Affected nodes:`);
+      cy.log('Affected nodes:');
 
       nodes.forEach(({ html, target }) => {
         cy.log(`  - HTML: ${html}`);
@@ -406,13 +406,13 @@ Then('I take a screenshot for Feature {int} and Scenario {int}', (featureNumber,
     switch (scenarioNumber) {
     case 1: scenarioString = '01 Confirm initial elements on View events page'; break;
     case 2: scenarioString = '02 Confirm initial elements on View processed payment requests page'; break;
-    case 3: scenarioString = '03 Load payment test data for later scenarios'; break;
-    case 4: scenarioString = '04 Search by FRN on View events page'; break;
-    case 5: scenarioString = '05 Search by Batch name on View events page'; break;
-    case 6: scenarioString = '06 Click View in Actions column and confirm page'; break;
-    case 7: scenarioString = '07 Confirm page elements when no results found'; break;
-    case 8: scenarioString = '08 View processed payment requests by scheme'; break;
-    case 9: scenarioString = '09 Confirm correct message when no results found'; break;
+    case 3: scenarioString = '03 Search by FRN on View events page'; break;
+    case 4: scenarioString = '04 Search by Batch name on View events page'; break;
+    case 5: scenarioString = '05 Click View in Actions column and confirm page'; break;
+    case 6: scenarioString = '06 Confirm page elements when no results found'; break;
+    case 7: scenarioString = '07 View processed payment requests by scheme'; break;
+    case 8: scenarioString = '08 Confirm correct message when no results found'; break;
+    case 9: scenarioString = '09 Confirm that payment request data is processed and ordered correctly'; break;
     }
     break;
   case 43: featureString = '43_PaymentAlerts.feature -- ';

--- a/cypress/integration/steps/paymentManagementSteps.js
+++ b/cypress/integration/steps/paymentManagementSteps.js
@@ -36,7 +36,6 @@ Then(/^I am on the "(.*)" subpage$/, (text) => {
 });
 
 When(/^the CSV file is downloaded with "(.*)" as the title$/, (text) => {
-  const relativePath = `cypress/downloads/${text}.csv`;
 
   if (text === 'ffc-pay-mi-report-v2' || text === 'ffc-pay-hold-report' || text === 'ffc-pay-suppressed-report') {
     const relativePath = `cypress/downloads/${text}.csv`;
@@ -327,7 +326,7 @@ Then(/^on the Manual Payments page I click the View payment status link and conf
 
   cy.wait(240000); // Waiting for the all payments to be processed and displayed on the Payment Status page
 
-  cy.get('a').contains("View payment status").scrollIntoView().click();
+  cy.get('a').contains('View payment status').scrollIntoView().click();
 
   const expectedFrns = ['1101264748', '1102172936', '1100510281', '1102368121', '1102468347',
     '1102383090', '1102316393', '1102353752', '1101123524', '1102420085', '1100064087', '1101327626',
@@ -942,12 +941,66 @@ Then (/^on the View events page I click the "(.*)"$/, (button) => {
   switch (button) {
   case 'frn search button': paymentEventMonitoringPage.searchByFRNButton().scrollIntoView().click(); break;
   case 'batch search button': paymentEventMonitoringPage.searchByBatchButton().scrollIntoView().click(); break;
-  case 'view link': paymentEventMonitoringPage.viewLink().scrollIntoView().click(); break;
-  default:
-    throw new Error('invalid button name');
+  case 'view link': cy.get(':nth-child(7) > a').then(($elements) => {
+    if ($elements.length > 0) {
+      $elements[0].click(); // Native JS click on the first element
+    } else {
+      throw new Error('No elements found for selector - nth-child(7) > a');
+    }
+  });
+    break;
   }
   cy.log(`Clicked on the ${button} successfully`);
   console.log(`Clicked on the ${button} successfully`);
+});
+
+Then (/^on the View events page I confirm that rows are ordered correctly by payment request$/, () => {
+
+  paymentEventMonitoringPage.firstPaymentRequestNumber().should('be.visible').and('contain.text', '1');
+  paymentEventMonitoringPage.secondPaymentRequestNumber().should('be.visible').and('contain.text', '2');
+
+  console.log('Confirmed that rows are ordered correctly by payment request');
+  cy.log('Confirmed that rows are ordered correctly by payment request');
+});
+
+Then (/^on the View events page I confirm that "(.*)" of entry number "(.*)" in table is "(.*)"$/, (columnName, rowNumber, expectedValue) => {
+
+  let element;
+
+  const today = new Date();
+
+  let day = today.getDate();
+  let month = today.getMonth() + 1;
+  let year = today.getFullYear();
+
+  day = String(day).padStart(2, '0');
+  month = String(month).padStart(2, '0');
+
+  const formattedDate = `${day}/${month}/${year}`;
+
+  console.log(formattedDate);
+  cy.log(formattedDate);
+
+  switch (columnName) {
+  case 'scheme': element = cy.get('.govuk-table__body > :nth-child(' + rowNumber + ') > :nth-child(1)'); break;
+  case 'agreement': element = cy.get('.govuk-table__body > :nth-child(' + rowNumber + ') > :nth-child(2)'); break;
+  case 'payment request': element = cy.get('.govuk-table__body > :nth-child(' + rowNumber + ') > :nth-child(3)'); break;
+  case 'value': element = cy.get('.govuk-table__body > :nth-child(' + rowNumber + ') > :nth-child(4)'); break;
+  case 'status': element = cy.get('.govuk-table__body > :nth-child(' + rowNumber + ') > :nth-child(5)'); break;
+  case 'last updated': element = cy.get('.govuk-table__body > :nth-child(' + rowNumber + ') > :nth-child(6)');
+
+    console.log(formattedDate);
+    cy.log(formattedDate);
+    expectedValue = formattedDate;
+    break;
+
+  default:
+    throw new Error('invalid element');
+  }
+  element.should('be.visible').and('contain.text', expectedValue);
+
+  console.log('Confirmed value of table entry ' + rowNumber + ' is ' + expectedValue);
+  cy.log('Confirmed value of table entry ' + rowNumber + ' is ' + expectedValue);
 });
 
 Then (/^on the Alerts page I confirm that "(.*)" is displayed$/, (element) => {
@@ -1083,7 +1136,7 @@ Then(/^on the Add new alert recipient page I confirm that all options are presen
   cy.document().then(doc => {
     const pageText = doc.body.innerText;
     stringsToCheck.forEach(str => {
-      const count = (pageText.match(new RegExp(str, "g")) || []).length;
+      const count = (pageText.match(new RegExp(str, 'g')) || []).length;
       expect(count, `Occurrences of "${str}"`).to.eq(15);
     });
   });
@@ -1119,7 +1172,7 @@ Then(/^on the Add new alert recipient page I confirm that only one set of option
   cy.document().then(doc => {
     const pageText = doc.body.innerText;
     stringsToCheck.forEach(str => {
-      const count = (pageText.match(new RegExp(str, "g")) || []).length;
+      const count = (pageText.match(new RegExp(str, 'g')) || []).length;
       expect(count, `Occurrences of "${str}"`).to.eq(1);
     });
   });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -10,15 +10,11 @@ const { spawn } = require('child_process');
 const loadReportData = require('../utils/loadReportData');
 const downloadStatementsBlobById = require('../utils/downloadStatementsBlobById');
 const downloadPaymentsBlobById = require('../utils/downloadPaymentsBlobById');
-const { exec } = require('child_process');
 const uploadFileToBlobStorage = require('../utils/uploadFileToBlobStorage');
 const generateJWT = require('../utils/generateJWT');
 const databaseQuery = require('../utils/databaseQuery');
 const databaseInsert = require('../utils/databaseInsert');
 const generateAccessToken = require('../utils/generateAccessToken');
-
-
-
 
 module.exports = (on, config) => {
   on('file:preprocessor', cucumber());


### PR DESCRIPTION
New scenario added to 42_PaymentEventMonitoring to test that following PPA processing the event data will display and be ordered correctly. 

Due to Cypress's limitations regarding running feature files that test multiple URLs, I have determined that the best course of action is to remove test data creation lines from 42_PaymentEventMonitoring entirely and instead run 32_SFI23Payments beforehand and this will create the necessary test data. Comments have been included at the start at feature 42 that pertain to this.